### PR TITLE
Use signal implementation of reset data

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -1620,22 +1620,12 @@ static NSTimeInterval launchStartedAt;
     [self stopLongPollerIfNeeded];
     [self.lokiNewsFeedPoller stop];
     [self.lokiMessengerUpdatesFeedPoller stop];
-    [OWSPrimaryStorage.sharedManager.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        [transaction removeAllObjectsInCollection:LKPublicChatAPI.lastMessageServerIDCollection];
-        [transaction removeAllObjectsInCollection:LKPublicChatAPI.lastDeletionServerIDCollection];
-        [transaction removeAllObjectsInCollection:@"LKMessageIDCollection"];
-        [transaction removeAllObjectsInCollection:@"LKLastMessageHashCollection"];
-        NSDictionary<NSString *, LKPublicChat *> *allPublicChats = [LKDatabaseUtilities getAllPublicChats:transaction];
-        for (NSString *threadID in allPublicChats.allKeys) {
-            [LKDatabaseUtilities removePublicChatForThreadID:threadID transaction:transaction];
-        }
-    }];
     [LKPublicChatManager.shared stopPollers];
-    [SSKEnvironment.shared.tsAccountManager resetForReregistration];
-    UIViewController *rootVC = [OnboardingController new].initialViewController;
-    OWSNavigationController *navigationVC = [[OWSNavigationController alloc] initWithRootViewController:rootVC];
-    [navigationVC setNavigationBarHidden:YES];
-    UIApplication.sharedApplication.keyWindow.rootViewController = navigationVC;
+    bool wasUnlinked = [NSUserDefaults.standardUserDefaults boolForKey:@"wasUnlinked"];
+    [SignalApp resetAppData:^{
+        // Resetting the data clears the old user defaults. We need to restore the unlink default.
+        [NSUserDefaults.standardUserDefaults setBool:wasUnlinked forKey:@"wasUnlinked"];
+    }];
 }
 
 @end

--- a/Signal/src/environment/SignalApp.h
+++ b/Signal/src/environment/SignalApp.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Methods
 
 + (void)resetAppData;
++ (void)resetAppData:(void (^__nullable)(void))onReset;
 
 
 - (void)showHomeView;

--- a/Signal/src/environment/SignalApp.m
+++ b/Signal/src/environment/SignalApp.m
@@ -162,6 +162,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)resetAppData
 {
+    [self resetAppData:nil];
+}
+
++ (void)resetAppData:(void (^__nullable)(void))onReset {
     // This _should_ be wiped out below.
     OWSLogError(@"");
     [DDLog flushLog];
@@ -172,6 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
     [AppEnvironment.shared.notificationPresenter clearAllNotifications];
 
     [DebugLogger.sharedLogger wipeLogs];
+    if(onReset != nil) { onReset(); }
     exit(0);
 }
 


### PR DESCRIPTION
Pros:
- Completely resets the whole database and fixes the issue with incorrect session which occurs after you register a new account after unlinking a device.
Cons:
- App exits instead of going back to the original screen
    - It crashes when you try show the landing page.